### PR TITLE
Update directory used to store fingerprints output

### DIFF
--- a/insights-operator-runtime/e2e/tomcat_test.go
+++ b/insights-operator-runtime/e2e/tomcat_test.go
@@ -47,7 +47,7 @@ func TestTomcat(t *testing.T) {
 			g.Expect(len(result.Runtimes)).To(Ω.Equal(1))
 			runtime := result.Runtimes[0]
 			g.Expect(runtime.Name).To(Ω.Equal("Apache Tomcat"))
-			g.Expect(runtime.Version).To(Ω.Equal("11.0.0-M20"))
+			g.Expect(runtime.Version).To(Ω.Equal("11.0.0-M21"))
 
 			return ctx
 		})

--- a/insights-operator-runtime/src/bin/scan-container.rs
+++ b/insights-operator-runtime/src/bin/scan-container.rs
@@ -1,9 +1,13 @@
 use clap::Parser;
-use insights_operator_runtime::config;
-use insights_operator_runtime::{RuntimeInfo, ScannerError};
 use log::{info, trace, warn};
 use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
 use std::time::Instant;
+
+use insights_operator_runtime::config;
+use insights_operator_runtime::file;
+use insights_operator_runtime::{RuntimeInfo, ScannerError};
 
 #[derive(Parser, Debug)]
 #[command(about, long_about = None)]
@@ -32,6 +36,12 @@ fn main() -> Result<(), ScannerError> {
 
     let container_id = args.container_id;
 
+    let exec_dir = format!("{}", std::process::id());
+    file::create_dir(&exec_dir).expect(&format!(
+        "Can not create execution directory  {}",
+        &exec_dir
+    ));
+
     info!("Scanning container 🫙 {}", container_id);
     if let Some(container) = insights_operator_runtime::get_container(&container_id) {
         if let Some(runtime_info) =
@@ -53,6 +63,8 @@ fn main() -> Result<(), ScannerError> {
             };
         }
     }
+
+    let _ = fs::remove_dir_all(PathBuf::from(&exec_dir));
 
     let duration = start.elapsed().as_millis();
     trace!("🕑 Scanned container in {:?}ms", duration);

--- a/insights-operator-runtime/src/bin/scan-containers.rs
+++ b/insights-operator-runtime/src/bin/scan-containers.rs
@@ -1,9 +1,12 @@
-use std::collections::HashMap;
-
 use clap::Parser;
-use insights_operator_runtime::config;
-use insights_operator_runtime::{RuntimeInfo, ScannerError};
 use log::{info, warn};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use insights_operator_runtime::config;
+use insights_operator_runtime::file;
+use insights_operator_runtime::{RuntimeInfo, ScannerError};
 
 #[derive(Parser, Debug)]
 #[command(about, long_about = None)]
@@ -24,6 +27,12 @@ fn main() -> Result<(), ScannerError> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level)).init();
 
     let config = config::get_config("/");
+
+    let exec_dir = format!("{}", std::process::id());
+    file::create_dir(&exec_dir).expect(&format!(
+        "Can not create execution directory  {}",
+        &exec_dir
+    ));
 
     info!("Scanning all containers");
     let containers = insights_operator_runtime::get_containers();
@@ -48,6 +57,8 @@ fn main() -> Result<(), ScannerError> {
         Err(_err) => warn!("Unable to serialize JSON"),
         Ok(json) => println!("{}", json),
     };
+
+    let _ = fs::remove_dir_all(PathBuf::from(&exec_dir));
 
     Ok(())
 }

--- a/insights-operator-runtime/src/bin/sleep.rs
+++ b/insights-operator-runtime/src/bin/sleep.rs
@@ -2,22 +2,19 @@ use std::fs;
 use std::thread;
 use std::time::Duration;
 
-use insights_operator_runtime::{config, file, perms};
+use insights_operator_runtime::{config, perms};
 
 fn main() {
     println!("Gather runtime information from containers on OpenShift");
 
     perms::check_privileged_perms().expect("Must have privileged permissions to scan containers");
 
-    // create a out directory to store all fingerprints data
-    file::create_dir("out").expect("Can not create output directory");
-
     // verify that the configuration is properly setup
     let config_content = fs::read_to_string("/config.toml").expect("Configuration file is missing");
     println!("Configuration:\n----\n{}\n----", config_content);
     config::get_config("/");
 
-    println!("\nRun the /gather-containers or /gather-container executables to extract runtime information from containers.");
+    println!("\nRun the /scan-containers or /scan-container executables to extract runtime information from containers.");
     println!("Sleeping 💤");
     thread::sleep(Duration::MAX);
 }

--- a/insights-operator-runtime/src/insights_operator_runtime/fingerprint.rs
+++ b/insights-operator-runtime/src/insights_operator_runtime/fingerprint.rs
@@ -10,7 +10,12 @@ mod os;
 mod version_executable;
 
 trait FingerPrint {
-    fn can_apply_to(&self, config: &Config, process: &ContainerProcess) -> Option<Vec<String>>;
+    fn can_apply_to(
+        &self,
+        config: &Config,
+        out_dir: &String,
+        process: &ContainerProcess,
+    ) -> Option<Vec<String>>;
 }
 
 fn fingerprints() -> Vec<Box<dyn FingerPrint>> {
@@ -22,11 +27,11 @@ fn fingerprints() -> Vec<Box<dyn FingerPrint>> {
     ]
 }
 
-pub fn run_fingerprints(config: &Config, process: &ContainerProcess) {
+pub fn run_fingerprints(config: &Config, out_dir: &String, process: &ContainerProcess) {
     debug!("👆 Fingerprinting process {}", &process.pid);
 
     for fingerprint in fingerprints() {
-        if let Some(exec) = fingerprint.can_apply_to(config, &process) {
+        if let Some(exec) = fingerprint.can_apply_to(config, &out_dir, &process) {
             debug!("Executing {:?}", &exec);
             if let Some((command, args)) = exec.split_first() {
                 let command = Command::new(&command).args(args).output();

--- a/insights-operator-runtime/src/insights_operator_runtime/fingerprint/native_executable.rs
+++ b/insights-operator-runtime/src/insights_operator_runtime/fingerprint/native_executable.rs
@@ -7,19 +7,23 @@ use crate::insights_operator_runtime::ContainerProcess;
 pub struct NativeExecutable {}
 
 impl FingerPrint for NativeExecutable {
-    fn can_apply_to(&self, _: &Config, process: &ContainerProcess) -> Option<Vec<String>> {
+    fn can_apply_to(
+        &self,
+        _: &Config,
+        out_dir: &String,
+        process: &ContainerProcess,
+    ) -> Option<Vec<String>> {
         debug!("Checking if {:#?} is a native executable", {
             &process.name
         });
 
         let fpr_kind_executable = String::from("./fpr_native_executable");
-        let outdir = format!("out/{}", process.pid);
 
         match !version_executable::is_version_executable(process) {
             false => None,
             true => Some(vec![
                 fpr_kind_executable,
-                outdir,
+                out_dir.to_string(),
                 process.cwd.as_ref().unwrap().clone(),
                 process.command_line.get(0)?.clone(),
             ]),

--- a/insights-operator-runtime/src/insights_operator_runtime/fingerprint/os.rs
+++ b/insights-operator-runtime/src/insights_operator_runtime/fingerprint/os.rs
@@ -6,10 +6,12 @@ use super::FingerPrint;
 pub struct Os {}
 
 impl FingerPrint for Os {
-    fn can_apply_to(&self, _config: &Config, process: &ContainerProcess) -> Option<Vec<String>> {
-        Some(vec![
-            String::from("./fpr_os"),
-            format!("out/{}", process.pid),
-        ])
+    fn can_apply_to(
+        &self,
+        _config: &Config,
+        out_dir: &String,
+        _process: &ContainerProcess,
+    ) -> Option<Vec<String>> {
+        Some(vec![String::from("./fpr_os"), out_dir.to_string()])
     }
 }

--- a/insights-operator-runtime/src/insights_operator_runtime/fingerprint/version_executable.rs
+++ b/insights-operator-runtime/src/insights_operator_runtime/fingerprint/version_executable.rs
@@ -7,14 +7,18 @@ use crate::insights_operator_runtime::ContainerProcess;
 pub struct VersionExecutable {}
 
 impl FingerPrint for VersionExecutable {
-    fn can_apply_to(&self, config: &Config, process: &ContainerProcess) -> Option<Vec<String>> {
+    fn can_apply_to(
+        &self,
+        config: &Config,
+        out_dir: &String,
+        process: &ContainerProcess,
+    ) -> Option<Vec<String>> {
         debug!(
             "Checking if {:#?} is an executable with that has a `--version`",
             { &process.name }
         );
 
         let fpr_kind_executable = String::from("./fpr_kind_executable");
-        let outdir = format!("out/{}", process.pid);
 
         if let Some(version_executable) = config
             .fingerprints
@@ -26,7 +30,7 @@ impl FingerPrint for VersionExecutable {
                 fpr_kind_executable,
                 String::from(&process.command_line[0]),
                 String::from(&version_executable.runtime_kind_name),
-                outdir,
+                out_dir.to_string(),
             ]);
         } else if process.command_line[0].contains("java") {
             // JAVA_HOME env var can not be set
@@ -34,7 +38,7 @@ impl FingerPrint for VersionExecutable {
             let java_home = process.environ.get("JAVA_HOME").unwrap_or(&no_java_home);
             return Some(vec![
                 String::from("./fpr_java_version"),
-                outdir,
+                out_dir.to_string(),
                 process.environ.get("PATH").unwrap().to_string(),
                 java_home.to_string(),
             ]);


### PR DESCRIPTION
Use the current process pid to create an execution directory where the inspected processes would store their output. This allows concurrent execution of the program without intermingling the extracted data.