### PR TITLE
add a  parameter to the exporter

### DIFF
--- a/exporter/cmd/exporter/main.go
+++ b/exporter/cmd/exporter/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/sha256"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -152,10 +153,15 @@ func collectWorkloadPayload(hash bool, dataPath string) (types.NodeRuntimeInfo, 
 }
 
 func main() {
+	bindAddress := flag.String("bind", "127.0.0.1", "Bind address")
+
+	flag.Parse()
+
 	http.HandleFunc("/gather_runtime_info", gatherRuntimeInfo)
 
-	log.Println("Starting exporter HTTP server at port 8000")
-	if err := http.ListenAndServe(":8000", nil); err != nil {
+	address := *bindAddress + ":8000"
+	log.Printf("Starting exporter HTTP server at %s\n", address)
+	if err := http.ListenAndServe(address, nil); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/exporter/test/e2e/main_test.go
+++ b/exporter/test/e2e/main_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
 )
 
 var (
@@ -28,7 +29,6 @@ func TestMain(m *testing.M) {
 	cfg, _ := envconf.NewFromFlags()
 	testEnv = env.NewWithConfig(cfg)
 	namespace = "e2e-insights-runtime-extractor"
-	// 	envconf.RandomName("e2e", 10)
 	insightsOperatorRuntimeNamespace = os.Getenv("TEST_NAMESPACE")
 	testedExtractorImage = "ghcr.io/jmesnil/insights-runtime-extractor:latest"
 	testedExporterImage = "ghcr.io/jmesnil/insights-runtime-exporter:latest"
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 	curl := newCurlDeployment()
 
 	testEnv.Setup(
-		//		envfuncs.CreateNamespace(namespace),
+		envfuncs.CreateNamespace(namespace),
 		deployAndWaitForReadiness(curl, "app.kubernetes.io/name=curl-e2e"),
 		deployAndWaitForReadiness(insightsOperatorRuntime, "app.kubernetes.io/name=insights-runtime-extractor-e2e"),
 	)
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 	testEnv.Finish(
 		undeploy(insightsOperatorRuntime),
 		undeploy(curl),
-		//		envfuncs.DeleteNamespace(namespace),
+		envfuncs.DeleteNamespace(namespace),
 	)
 
 	os.Exit(testEnv.Run(m))
@@ -101,6 +101,7 @@ func newContainerScannerDaemonSet() *appsv1.DaemonSet {
 							MountPath: "/data",
 							Name:      "data-volume",
 						}},
+						Command: []string{"/exporter", "-bind", "0.0.0.0"},
 					}},
 					Volumes: []corev1.Volume{{
 						Name: "crio-socket",


### PR DESCRIPTION
* By default, bind to 127.0.0.1
* In the e2e tests, bind to 0.0.0.0 to be able to access the exporter from another pod